### PR TITLE
Check if bintray.properties file exists before accessing it

### DIFF
--- a/annotations/bintray.gradle
+++ b/annotations/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/core/bintray.gradle
+++ b/core/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/generator/bintray.gradle
+++ b/generator/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/lint/bintray.gradle
+++ b/lint/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/plugin/bintray.gradle
+++ b/plugin/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/processor/bintray.gradle
+++ b/processor/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/ui-no-op/bintray.gradle
+++ b/ui-no-op/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version

--- a/ui/bintray.gradle
+++ b/ui/bintray.gradle
@@ -3,7 +3,10 @@ apply plugin: "com.jfrog.bintray"
 apply plugin: 'com.github.dcendents.android-maven'
 
 Properties properties = new Properties()
-properties.load(new FileInputStream(file(rootProject.file('bintray.properties'))))
+def bintrayProps = rootProject.file('bintray.properties')
+if (bintrayProps.exists()) {
+    properties.load(new FileInputStream(file(bintrayProps)))
+}
 
 group = collar.group
 version = collar.version


### PR DESCRIPTION
## :page_facing_up: Context
Due to the `bintray.properties` file not being tracked in the repository, new contributors couldn't even build the project after the cloning process.

## :pencil: Changes
I've added checks to all `bintray.gradle` files to see if the `bintray.properties` file actually exists before acccessing it.

## :hammer_and_wrench: How to test
Try to build the project with no `bintray.properties` file. If the build succeeds, the fix works!