### PR TITLE
Remove GPG block from all bintray.gradle configs

### DIFF
--- a/annotations/bintray.gradle
+++ b/annotations/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/core/bintray.gradle
+++ b/core/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/generator/bintray.gradle
+++ b/generator/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/lint/bintray.gradle
+++ b/lint/bintray.gradle
@@ -68,10 +68,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/plugin/bintray.gradle
+++ b/plugin/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/processor/bintray.gradle
+++ b/processor/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/ui-no-op/bintray.gradle
+++ b/ui-no-op/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true

--- a/ui/bintray.gradle
+++ b/ui/bintray.gradle
@@ -71,10 +71,6 @@ bintray {
             name = "${collar.version}"
             released = new Date()
             vcsTag = "${collar.version}"
-            gpg {
-                sign = true
-                passphrase = properties.getProperty("bintray.gpg_passphrase")
-            }
         }
         publish = true
         override = true


### PR DESCRIPTION
We've discovered that the GPG block isn't necessary for Android builds.