### PR TITLE
Fix max line rule breakage

### DIFF
--- a/ui/src/main/kotlin/co/infinum/collar/ui/presentation/CollarActivity.kt
+++ b/ui/src/main/kotlin/co/infinum/collar/ui/presentation/CollarActivity.kt
@@ -154,7 +154,8 @@ internal class CollarActivity : AppCompatActivity() {
                 with(viewBinding) {
                     collectionStatusCard.isGone = it.analyticsCollectionEnabled
                     collectionStatusTimestamp.text =
-                        SimpleDateFormat(FORMAT_DATETIME, Locale.getDefault()).format(Date((it.analyticsCollectionTimestamp)))
+                        SimpleDateFormat(FORMAT_DATETIME, Locale.getDefault())
+                            .format(Date((it.analyticsCollectionTimestamp)))
                 }
             }
         }


### PR DESCRIPTION
Detekt isn't doing anything to help me today. Now it's complaining that the max line length rule is broken (default value 120 chars).